### PR TITLE
Make sidechain contracts remember claimed events

### DIFF
--- a/algorithms/crosschain.tex
+++ b/algorithms/crosschain.tex
@@ -13,7 +13,7 @@
                     \Comment{Ensure sufficient collateral}
                     \State\Return{$\bot$}
                 \EndIf
-                \If{$\textsf{events}[e] = \bot \land \textsf{verify}^{e, \mathcal{G}}_{k,m}(\{\pi\})$}
+                \If{$\textsf{events}[e] = \bot \land \textsf{verify}^{e, \mathcal{G}}_{k,m}(\pi)$}
                     \Let{\textsf{events}[e]}{\{\textsf{expire: } \textsf{block.number} + k,
                                                \textsf{proof: } \pi,
                                                \textsf{author: } \textsf{msg.sender}\}}
@@ -35,7 +35,7 @@
                      \lor \textsf{block.number} \geq \textsf{events}[e].\textsf{expire}$}
                     \State\Return{$\bot$}
                 \EndIf
-                \If{$\lnot \textsf{verify}^{e, \mathcal{G}}_{k,m}(\{\textsf{events}[e].\textsf{proof}, \pi^*\})$}
+                \If{$\lnot \textsf{verify}^{e, \mathcal{G}}_{k,m}(\textsf{events}[e].\textsf{proof}, \pi^*)$}
                     \Comment{Original proof was fraudulent}
                     \Let{\textsf{events}[e]}{\bot}
                     \State\textsf{msg.sender.send}(z)

--- a/algorithms/sidechain.tex
+++ b/algorithms/sidechain.tex
@@ -10,17 +10,18 @@
                 \If{$\lnot \textsf{initialized}$}
                     \State\textsf{crosschain.initialize}$(\mathcal{G}_2)$
                     \Comment{Initialize with the remote chain genesis block}
-                    \Let{\textsf{initialized}}{\emph{true}}
-                    \Let{{\sf this.sidechain}_2}{\textsf{sidechain}_2}
+                    \State{%
+                           $\textsf{this.sidechain}_2 \gets \textsf{sidechain}_2$;
+                           $\textsf{initialized} \gets \emph{true}$
+                    }
                 \EndIf
             \EndFunction
             \Payable{\sf deposit}{{\sf target}}
                 \CommentLine{Emit an event to be picked up by remote contract}
-                \State{$\textsf{ctr} \pluseq 1$}
                 \State{\textsf{emit}
                        \textsf{Deposited}$_1$(\textsf{target},
                                               \textsf{msg.value},
-                                              \textsf{ctr})}
+                                              \textsf{ctr}\plusplus)}
             \EndPayable
             \Function{\sf withdraw}{$\textsf{amount}, \textsf{target}, \textsf{ctr}$}
                 \CommentLine{Validate that event took place on remote chain}
@@ -43,8 +44,10 @@
             \Function{\sf initialize}{$\mathcal{G}_1$, \textsf{sidechain}$_1$}
                 \If{$\lnot \textsf{initialized}$}
                     \State\textsf{crosschain.initialize}$(\mathcal{G}_1)$
-                    \Let{\textsf{initialized}}{\emph{true}}
-                    \Let{{\sf this.sidechain}_1}{\textsf{sidechain}_1}
+                    \State{%
+                           $\textsf{this.sidechain}_1 \gets \textsf{sidechain}_1$;
+                           $\textsf{initialized} \gets \emph{true}$
+                    }
                 \EndIf
             \EndFunction
             \Function{\sf deposit}{{\sf target}, {\sf amount}}
@@ -53,11 +56,10 @@
                 \EndIf
                 \State{$\textsf{balances[msg.sender]} \minuseq \textsf{amount}$}
                 \Comment{Charge account of sender}
-                \State{$\textsf{ctr} \pluseq 1$}
                 \State{\textsf{emit}
                        \textsf{Deposited}$_2$(\textsf{target},
                                               \textsf{amount},
-                                              \textsf{ctr})}
+                                              \textsf{ctr}\plusplus)}
             \EndFunction
             \Function{\sf withdraw}{$\textsf{amount}, \textsf{target}, \textsf{ctr}$}
                 \Let{\textsf{event}}{(

--- a/algorithms/sidechain.tex
+++ b/algorithms/sidechain.tex
@@ -4,7 +4,8 @@
     \begin{algorithmic}[1]
         \Contract{\textsf{sidechain}$_1$\text{ extends }\textsf{crosschain}$_{k,m,z}$}
             \State{$\textsf{initialized} \gets \emph{false}$;
-                   $\textsf{ctr} \gets 0$}
+                   $\textsf{ctr} \gets 0$;
+                   $\textsf{claimed-events} \gets \emptyset$}
             \Function{\sf initialize}{$\mathcal{G}_2$, \textsf{sidechain}$_2$}
                 \If{$\lnot \textsf{initialized}$}
                     \State\textsf{crosschain.initialize}$(\mathcal{G}_2)$
@@ -23,23 +24,22 @@
             \EndPayable
             \Function{\sf withdraw}{$\textsf{amount}, \textsf{target}, \textsf{ctr}$}
                 \CommentLine{Validate that event took place on remote chain}
-                \If{$\lnot
-                         \textsf{event-exists}(
-                             (
+                \Let{\textsf{event}}{(
                                 \textsf{sidechain}_2,
                                 \textsf{Deposited}_2,
-                                (\textsf{amount}, \textsf{target}, \textsf{ctr})
-                             )
-                         )$}
+                                (\textsf{amount}, \textsf{target}, \textsf{ctr}))}
+                \If{$\textsf{event} \in \textsf{claimed-events} \lor \lnot \textsf{event-exists}(\textsf{event})$}
                     \State\Return{$\bot$}
                 \EndIf
+                \Let{\textsf{claimed-events}}{\textsf{claimed-events} \cup \{\textsf{event}\}}
                 \State\textsf{msg.sender.send}(\textsf{amount})
             \EndFunction
         \EndContract
         \Contract{\textsf{sidechain}$_2$\text{ extends }\textsf{crosschain}$_{k,m,z}$; \textsf{ERC20}}
             \State\textsf{mapping}(\textsf{address} $\Rightarrow$ \textsf{int}) \textsf{balances}
             \State{$\textsf{initialized} \gets \emph{false}$;
-                   $\textsf{ctr} \gets 0$}
+                   $\textsf{ctr} \gets 0$;
+                   $\textsf{claimed-events} \gets \emptyset$}
             \Function{\sf initialize}{$\mathcal{G}_1$, \textsf{sidechain}$_1$}
                 \If{$\lnot \textsf{initialized}$}
                     \State\textsf{crosschain.initialize}$(\mathcal{G}_1)$
@@ -60,16 +60,14 @@
                                               \textsf{ctr})}
             \EndFunction
             \Function{\sf withdraw}{$\textsf{amount}, \textsf{target}, \textsf{ctr}$}
-                \If{$\lnot
-                         \textsf{event-exists}(
-                             (
+                \Let{\textsf{event}}{(
                                 \textsf{sidechain}_1,
                                 \textsf{Deposited}_1,
-                                (\textsf{amount}, \textsf{target}, \textsf{ctr})
-                             )
-                         )$}
+                                (\textsf{amount}, \textsf{target}, \textsf{ctr}))}
+                \If{$\textsf{event} \in \textsf{claimed-events} \lor \lnot \textsf{event-exists}(\textsf{event})$}
                     \State\Return{$\bot$}
                 \EndIf
+                \Let{\textsf{claimed-events}}{\textsf{claimed-events} \cup \{\textsf{event}\}}
                 \State{$\textsf{balances[target]} \pluseq \textsf{amount}$}
                 \Comment{Credit target account}
             \EndFunction

--- a/algorithms/sidechain.tex
+++ b/algorithms/sidechain.tex
@@ -25,14 +25,14 @@
             \EndPayable
             \Function{\sf withdraw}{$\textsf{amount}, \textsf{target}, \textsf{ctr}$}
                 \CommentLine{Validate that event took place on remote chain}
-                \Let{\textsf{event}}{(
+                \Let{e}{(
                                 \textsf{sidechain}_2,
                                 \textsf{Deposited}_2,
                                 (\textsf{amount}, \textsf{target}, \textsf{ctr}))}
-                \If{$\textsf{event} \in \textsf{claimed-events} \lor \lnot \textsf{event-exists}(\textsf{event})$}
+                \If{$e \in \textsf{claimed-events} \lor \lnot \textsf{event-exists}(e)$}
                     \State\Return{$\bot$}
                 \EndIf
-                \Let{\textsf{claimed-events}}{\textsf{claimed-events} \cup \{\textsf{event}\}}
+                \Let{\textsf{claimed-events}}{\textsf{claimed-events} \cup \{e\}}
                 \State\textsf{msg.sender.send}(\textsf{amount})
             \EndFunction
         \EndContract
@@ -62,14 +62,14 @@
                                               \textsf{ctr}\plusplus)}
             \EndFunction
             \Function{\sf withdraw}{$\textsf{amount}, \textsf{target}, \textsf{ctr}$}
-                \Let{\textsf{event}}{(
+                \Let{e}{(
                                 \textsf{sidechain}_1,
                                 \textsf{Deposited}_1,
                                 (\textsf{amount}, \textsf{target}, \textsf{ctr}))}
-                \If{$\textsf{event} \in \textsf{claimed-events} \lor \lnot \textsf{event-exists}(\textsf{event})$}
+                \If{$e \in \textsf{claimed-events} \lor \lnot \textsf{event-exists}(e)$}
                     \State\Return{$\bot$}
                 \EndIf
-                \Let{\textsf{claimed-events}}{\textsf{claimed-events} \cup \{\textsf{event}\}}
+                \Let{\textsf{claimed-events}}{\textsf{claimed-events} \cup \{e\}}
                 \State{$\textsf{balances[target]} \pluseq \textsf{amount}$}
                 \Comment{Credit target account}
             \EndFunction

--- a/preamble.sty
+++ b/preamble.sty
@@ -118,10 +118,10 @@
 \hyphenation{NI-Po-PoW}
 \hyphenation{NI-Po-PoWs}
 
-\newcommand{\pluseq}{\mathrel{+}=}
-\newcommand{\minuseq}{\mathrel{-}=}
-\newcommand{\stareq}{\mathrel{*}=}
-\newcommand{\slasheq}{\mathrel{/}=}
+\newcommand{\pluseq}{\texttt{\,+=\,}}
+\newcommand{\minuseq}{\texttt{\,-=\,}}
+\newcommand{\stareq}{\texttt{\,*=\,}}
+\newcommand{\slasheq}{\texttt{\,/=\,}}
 \newcommand{\plusplus}{\texttt{++}}
 
 \newcommand\blfootnote[1]{%

--- a/preamble.sty
+++ b/preamble.sty
@@ -122,6 +122,7 @@
 \newcommand{\minuseq}{\mathrel{-}=}
 \newcommand{\stareq}{\mathrel{*}=}
 \newcommand{\slasheq}{\mathrel{/}=}
+\newcommand{\plusplus}{\texttt{++}}
 
 \newcommand\blfootnote[1]{%
   \begingroup


### PR DESCRIPTION
This mitigates the attack where someone can withdraw multiple times by submitting the same event.