### PR TITLE
On withdrawal send funds to actual recipient

### DIFF
--- a/algorithms/sidechain.tex
+++ b/algorithms/sidechain.tex
@@ -33,7 +33,7 @@
                          )$}
                     \State\Return{$\bot$}
                 \EndIf
-                \State\textsf{msg.sender.send}(\textsf{amount})
+                \State\textsf{target.send}(\textsf{amount})
             \EndFunction
         \EndContract
         \Contract{\textsf{sidechain}$_2$\text{ extends }\textsf{crosschain}$_{k,m,z}$; \textsf{ERC20}}


### PR DESCRIPTION
The contract previously sent the funds to the submitter instead.